### PR TITLE
Update web route with statamic v4 syntax

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -1,5 +1,6 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use Plugrbase\MaintenanceMode\Http\Controllers\MaintenanceModeController;
 
-Route::get('/maintenance-mode', 'MaintenanceModeController@index')->name('plugrbase.maintenance.index');
+Route::get('/maintenance-mode', [MaintenanceModeController::class, 'index'])->name('plugrbase.maintenance.index');


### PR DESCRIPTION
Updates the web routes file to use the new action route syntax. 

From the upgrade guide Static 3 -> 4

https://statamic.dev/upgrade-guide/3-4-to-4-0#route-namespaces-have-been-removed